### PR TITLE
Pass auth in the constructor of network providers.

### DIFF
--- a/erdpy_network/api_network_provider.py
+++ b/erdpy_network/api_network_provider.py
@@ -1,28 +1,34 @@
+from typing import Any, Dict, List, Union
+
 import requests
 from requests.auth import AuthBase
-from typing import Union, Dict, List, Any
-from erdpy_network.errors import GenericError
-from erdpy_network.utils import decimal_to_padded_hex
-from erdpy_network.network_stake import NetworkStake
+
 from erdpy_network.accounts import AccountOnNetwork
+from erdpy_network.config import DefaultPagination
 from erdpy_network.contract_query_requests import ContractQueryRequest
 from erdpy_network.contract_query_response import ContractQueryResponse
-from erdpy_network.network_general_statistics import NetworkGeneralStatistics
-from erdpy_network.tokens import FungibleTokenOfAccountOnNetwork, NonFungibleTokenOfAccountOnNetwork
-from erdpy_network.token_definitions import DefinitionOfFungibleTokenOnNetwork, DefinitionOfTokenCollectionOnNetwork
-from erdpy_network.transactions import TransactionOnNetwork
-from erdpy_network.interface import IAddress, IPagination, IContractQuery, ITransaction
-from erdpy_network.transaction_status import TransactionStatus
-from erdpy_network.proxy_network_provider import ProxyNetworkProvider
-from erdpy_network.config import DefaultPagination
+from erdpy_network.errors import GenericError
+from erdpy_network.interface import (IAddress, IContractQuery, IPagination,
+                                     ITransaction)
 from erdpy_network.network_config import NetworkConfig
+from erdpy_network.network_general_statistics import NetworkGeneralStatistics
+from erdpy_network.network_stake import NetworkStake
 from erdpy_network.network_status import NetworkStatus
+from erdpy_network.proxy_network_provider import ProxyNetworkProvider
+from erdpy_network.token_definitions import (
+    DefinitionOfFungibleTokenOnNetwork, DefinitionOfTokenCollectionOnNetwork)
+from erdpy_network.tokens import (FungibleTokenOfAccountOnNetwork,
+                                  NonFungibleTokenOfAccountOnNetwork)
+from erdpy_network.transaction_status import TransactionStatus
+from erdpy_network.transactions import TransactionOnNetwork
+from erdpy_network.utils import decimal_to_padded_hex
 
 
 class ApiNetworkProvider:
-    def __init__(self, url: str, backing_proxy_network_provider: ProxyNetworkProvider):
+    def __init__(self, url: str, backing_proxy_network_provider: ProxyNetworkProvider, auth: Union[AuthBase, None] = None):
         self.url = url
         self.backing_proxy = backing_proxy_network_provider
+        self.auth = auth
 
     def get_network_config(self) -> NetworkConfig:
         return self.backing_proxy.get_network_config()
@@ -140,9 +146,9 @@ class ApiNetworkProvider:
         response = self.do_post(url, payload)
         return response
 
-    def do_get(self, url: str, auth: Union[AuthBase, None] = None):
+    def do_get(self, url: str):
         try:
-            response = requests.get(url, auth=auth)
+            response = requests.get(url, auth=self.auth)
             response.raise_for_status()
             parsed = response.json()
             return self._get_data(parsed, url)
@@ -156,7 +162,7 @@ class ApiNetworkProvider:
 
     def do_post(self, url: str, payload: Any):
         try:
-            response = requests.post(url, json=payload)
+            response = requests.post(url, json=payload, auth=self.auth)
             response.raise_for_status()
             parsed = response.json()
             return self._get_data(parsed, url)

--- a/erdpy_network/proxy_network_provider.py
+++ b/erdpy_network/proxy_network_provider.py
@@ -1,24 +1,30 @@
+from typing import Any, Dict, List, Union
+
 import requests
+from requests.auth import AuthBase
 from requests.models import PreparedRequest
-from typing import List, Any, Dict, Union
-from erdpy_network.interface import IAddress, ITransaction, IContractQuery
-from erdpy_network.constants import ESDT_CONTRACT_ADDRESS, METACHAIN_ID
+
 from erdpy_network.accounts import AccountOnNetwork
-from erdpy_network.tokens import FungibleTokenOfAccountOnNetwork, NonFungibleTokenOfAccountOnNetwork
-from erdpy_network.resources import GenericResponse
-from erdpy_network.errors import GenericError
-from erdpy_network.network_config import NetworkConfig
-from erdpy_network.network_status import NetworkStatus
-from erdpy_network.transactions import TransactionOnNetwork
-from erdpy_network.transaction_status import TransactionStatus
+from erdpy_network.constants import ESDT_CONTRACT_ADDRESS, METACHAIN_ID
 from erdpy_network.contract_query_requests import ContractQueryRequest
 from erdpy_network.contract_query_response import ContractQueryResponse
-from erdpy_network.token_definitions import DefinitionOfFungibleTokenOnNetwork, DefinitionOfTokenCollectionOnNetwork
+from erdpy_network.errors import GenericError
+from erdpy_network.interface import IAddress, IContractQuery, ITransaction
+from erdpy_network.network_config import NetworkConfig
+from erdpy_network.network_status import NetworkStatus
+from erdpy_network.resources import GenericResponse
+from erdpy_network.token_definitions import (
+    DefinitionOfFungibleTokenOnNetwork, DefinitionOfTokenCollectionOnNetwork)
+from erdpy_network.tokens import (FungibleTokenOfAccountOnNetwork,
+                                  NonFungibleTokenOfAccountOnNetwork)
+from erdpy_network.transaction_status import TransactionStatus
+from erdpy_network.transactions import TransactionOnNetwork
 
 
 class ProxyNetworkProvider:
-    def __init__(self, url: str):
+    def __init__(self, url: str, auth: Union[AuthBase, None] = None):
         self.url = url
+        self.auth = auth
 
     def get_network_config(self) -> NetworkConfig:
         response = self.do_get_generic('network/config')
@@ -133,7 +139,7 @@ class ProxyNetworkProvider:
 
     def do_get(self, url: str) -> GenericResponse:
         try:
-            response = requests.get(url)
+            response = requests.get(url, auth=self.auth)
             response.raise_for_status()
             parsed = response.json()
             return self.get_data(parsed, url)
@@ -147,7 +153,7 @@ class ProxyNetworkProvider:
 
     def do_post(self, url: str, payload: Any) -> GenericResponse:
         try:
-            response = requests.post(url, json=payload)
+            response = requests.post(url, json=payload, auth=self.auth)
             response.raise_for_status()
             parsed = response.json()
             return self.get_data(parsed, url)

--- a/erdpy_network/proxy_network_provider.py
+++ b/erdpy_network/proxy_network_provider.py
@@ -169,11 +169,11 @@ class ProxyNetworkProvider:
         err = parsed.get("error")
         code = parsed.get("code")
 
-        if not err and code == "successful":
-            data: Dict[str, Any] = parsed.get("data", dict())
-            return GenericResponse(data)
+        if err:
+            raise GenericError(url, f"code:{code}, error: {err}")
 
-        raise GenericError(url, f"code:{code}, error: {err}")
+        data: Dict[str, Any] = parsed.get("data", dict())
+        return GenericResponse(data)
 
     def _extract_error_from_response(self, response: Any):
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "erdpy_network"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
 - Pass `auth` in the constructor of network providers.
 - Handle missing `code` for proxy responses. 