### PR TITLE
Add send_transactions endpoint for proxy

### DIFF
--- a/erdpy_network/api_network_provider.py
+++ b/erdpy_network/api_network_provider.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union, Optional, cast
+from typing import Any, Dict, List, Union, Optional, Tuple, cast
 
 import requests
 from requests.auth import AuthBase
@@ -126,12 +126,17 @@ class ApiNetworkProvider:
 
         return status
 
-    def send_transaction(self, payload: ITransaction) -> str:
-        url = f'{self.url}/transaction/send'
-        response = self.do_post_generic(url, payload.to_dictionary())
+    def send_transaction(self, transaction: ITransaction) -> str:
+        url = f'{self.url}/transactions'
+        response = self.do_post_generic(url, transaction.to_dictionary())
         tx_hash: str = response.get('txHash', '')
 
         return tx_hash
+    
+    def send_transactions(self, transactions: List[ITransaction]) -> Tuple[int, str]:
+        response = self.backing_proxy.send_transactions(transactions)
+
+        return response
 
     def _build_pagination_params(self, pagination: IPagination) -> str:
         return f'from={pagination.get_start()}&size={pagination.get_size()}'

--- a/erdpy_network/proxy_network_provider.py
+++ b/erdpy_network/proxy_network_provider.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union, Optional
+from typing import Any, Dict, List, Union, Optional, Tuple
 
 import requests
 from requests.auth import AuthBase
@@ -88,6 +88,13 @@ class ProxyNetworkProvider:
     def send_transaction(self, tx: ITransaction) -> str:
         response = self.do_post_generic('transaction/send', tx.to_dictionary())
         return response.get('txHash', '')
+    
+    def send_transactions(self, transactions: List[ITransaction]) -> Tuple[int, str]:
+        response = self.do_post_generic('trasaction/send-multiple', transactions)
+        # Proxy and Observers have different response format:
+        num_sent = response.get("numOfSentTxs", 0) or response.get("txsSent", 0)
+        hashes = response.get("txsHashes")
+        return num_sent, hashes
 
     def query_contract(self, query: IContractQuery) -> ContractQueryResponse:
         request = ContractQueryRequest(query).to_http_request()

--- a/erdpy_network/proxy_network_provider.py
+++ b/erdpy_network/proxy_network_provider.py
@@ -85,15 +85,17 @@ class ProxyNetworkProvider:
 
         return status
 
-    def send_transaction(self, tx: ITransaction) -> str:
-        response = self.do_post_generic('transaction/send', tx.to_dictionary())
+    def send_transaction(self, transaction: ITransaction) -> str:
+        response = self.do_post_generic('transaction/send', transaction.to_dictionary())
         return response.get('txHash', '')
     
     def send_transactions(self, transactions: List[ITransaction]) -> Tuple[int, str]:
-        response = self.do_post_generic('trasaction/send-multiple', transactions)
+        transactions_as_dictionaries = [transaction.to_dictionary() for transaction in transactions]
+        response = self.do_post_generic('trasaction/send-multiple', transactions_as_dictionaries)
         # Proxy and Observers have different response format:
         num_sent = response.get("numOfSentTxs", 0) or response.get("txsSent", 0)
         hashes = response.get("txsHashes")
+
         return num_sent, hashes
 
     def query_contract(self, query: IContractQuery) -> ContractQueryResponse:

--- a/erdpy_network/proxy_network_provider.py
+++ b/erdpy_network/proxy_network_provider.py
@@ -91,7 +91,7 @@ class ProxyNetworkProvider:
     
     def send_transactions(self, transactions: List[ITransaction]) -> Tuple[int, str]:
         transactions_as_dictionaries = [transaction.to_dictionary() for transaction in transactions]
-        response = self.do_post_generic('trasaction/send-multiple', transactions_as_dictionaries)
+        response = self.do_post_generic('transaction/send-multiple', transactions_as_dictionaries)
         # Proxy and Observers have different response format:
         num_sent = response.get("numOfSentTxs", 0) or response.get("txsSent", 0)
         hashes = response.get("txsHashes")


### PR DESCRIPTION
Added a new endpoint called `send_transactions` that uses the `transaction/send-multiple` proxy endpoint the send multiple transactions at once.